### PR TITLE
feat: support repeated properties

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -22,14 +22,11 @@ class Converter {
   getType(schema) {
     let {repeated, ...schemaCopy} = schema;
 
+    if (repeated) {
+      return `Array<${this.getType(schemaCopy)}>`;
+    }
     if (schema.$ref) {
       return this.toTypeName(schema.$ref);
-    }
-    if (repeated) {
-      if (schema.enum) {
-        return `Array<${this.getType(schemaCopy)}>`;
-      }
-      return `Array<${this.getType(schemaCopy)}>`;
     }
     if (schema.enum) {
       return this.toLiteralUnion(schema.enum);

--- a/src/converter.js
+++ b/src/converter.js
@@ -23,6 +23,12 @@ class Converter {
     if (schema.$ref) {
       return this.toTypeName(schema.$ref);
     }
+    if (schema.repeated == true) {
+      if (schema.enum) {
+        return `Array<${this.toLiteralUnion(schema.enum)}>`;
+      }
+      return `Array<${schema.type}>`;
+    }
     if (schema.enum) {
       return this.toLiteralUnion(schema.enum);
     }

--- a/src/converter.js
+++ b/src/converter.js
@@ -20,14 +20,16 @@ class Converter {
     return [type, ...refs].join('&');
   }
   getType(schema) {
+    let {repeated, ...schemaCopy} = schema;
+
     if (schema.$ref) {
       return this.toTypeName(schema.$ref);
     }
-    if (schema.repeated == true) {
+    if (repeated) {
       if (schema.enum) {
-        return `Array<${this.toLiteralUnion(schema.enum)}>`;
+        return `Array<${this.getType(schemaCopy)}>`;
       }
-      return `Array<${schema.type}>`;
+      return `Array<${this.getType(schemaCopy)}>`;
     }
     if (schema.enum) {
       return this.toLiteralUnion(schema.enum);

--- a/test/fixtures/complex/schema.json
+++ b/test/fixtures/complex/schema.json
@@ -72,6 +72,19 @@
               }
             }
           }
+        },
+        "repeatedEnum": {
+          "repeated": true,
+          "type": "string",
+          "enum": [
+            "done",
+            "pending",
+            "running"
+          ]
+        },
+        "repeatedString": {
+          "repeated": true,
+          "type": "string"
         }
       }
     },

--- a/test/fixtures/complex/schema.json
+++ b/test/fixtures/complex/schema.json
@@ -73,7 +73,7 @@
             }
           }
         },
-        "repeatedEnum": {
+        "repeated": {
           "repeated": true,
           "type": "string",
           "enum": [
@@ -82,9 +82,19 @@
             "running"
           ]
         },
-        "repeatedString": {
+        "nestedRepeated": {
           "repeated": true,
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "nestedRepeatedProp": {
+              "repeated": true,
+              "type": "string",
+              "enum": [
+                "foo",
+                "bar"
+              ]
+            }
+          }
         }
       }
     },

--- a/test/fixtures/complex/types.d.ts
+++ b/test/fixtures/complex/types.d.ts
@@ -29,10 +29,10 @@ declare namespace complex {
        */
       nestedProp?: IExtendedSchema;
     }>;
+    nestedRepeated?: Array<{ nestedRepeatedProp?: Array<'foo' | 'bar'> }>;
     obj?: { key?: string; [key: string]: string };
     readonly readOnly?: string;
-    repeatedEnum?: Array<'done' | 'pending' | 'running'>;
-    repeatedString?: Array<string>;
+    repeated?: Array<'done' | 'pending' | 'running'>;
     required: string;
     tuple?: [string, number];
   };

--- a/test/fixtures/complex/types.d.ts
+++ b/test/fixtures/complex/types.d.ts
@@ -31,6 +31,8 @@ declare namespace complex {
     }>;
     obj?: { key?: string; [key: string]: string };
     readonly readOnly?: string;
+    repeatedEnum?: Array<'done' | 'pending' | 'running'>;
+    repeatedString?: Array<string>;
     required: string;
     tuple?: [string, number];
   };


### PR DESCRIPTION
The BigQuery discovery doc now contains a property, `stateFilter` that is specified as a `repeated` field.
```
"stateFilter": {
              "location": "query",
              "enumDescriptions": [
                "Finished jobs",
                "Pending jobs",
                "Running jobs"
              ],
              "repeated": true,
              "description": "Filter for job state",
              "type": "string",
              "enum": [
                "done",
                "pending",
                "running"
              ]
            },
```
The type is currently being generated as a string rather than an Array type (See: https://github.com/googleapis/nodejs-bigquery/issues/1089). This PR updates `converter.js` to check for the `repeated` key.