### PR TITLE
feat: Support passing in literal numbers on uint64 and int64 types

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -34,6 +34,9 @@ class Converter {
     if (schema.type === 'integer') {
       return 'number';
     }
+    if (schema.type === 'string' && (schema.format === 'uint64' || schema.format === 'int64')) {
+      return 'number | string';
+    }
     if (schema.type === 'array') {
       return this.toArray(schema.items, schema.additionalItems);
     }

--- a/test/fixtures/complex/schema.json
+++ b/test/fixtures/complex/schema.json
@@ -17,6 +17,14 @@
         "integer": {
           "type": "integer"
         },
+        "unsigned64BitInt": {
+          "type": "string",
+          "format": "uint64"
+        },
+        "signed64BitInt": {
+          "type": "string",
+          "format": "int64"
+        },
         "doc": {
           "type": "string",
           "description": "A description"

--- a/test/fixtures/complex/types.d.ts
+++ b/test/fixtures/complex/types.d.ts
@@ -34,7 +34,9 @@ declare namespace complex {
     readonly readOnly?: string;
     repeated?: Array<'done' | 'pending' | 'running'>;
     required: string;
+    signed64BitInt?: number | string;
     tuple?: [string, number];
+    unsigned64BitInt?: number | string;
   };
 }
 


### PR DESCRIPTION
Accepts both string and number when the API expects uint64 or int64.

This solution allows regular JS integers (2^53-1) but can also take a string for larger numbers if needed. 

See https://github.com/googleapis/google-cloud-node/issues/7230 for specific discussion on issue.